### PR TITLE
Use UMD header for universal package usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,19 @@
   By Louis T. <louist@ltdev.im>
   https://github.com/LouisT/SeededShuffle/
 */
-(function(Setup){
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], function () {
+      return (root.SeededShuffle = factory());
+    });
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    // Browser globals
+    root.SeededShuffle = factory();
+  }
+}(this, function () {
    var proto = {
        strSeed: null,
        shuffle: function (arr, seed, copy) {
@@ -55,7 +67,5 @@
              return Object.prototype.toString.call(obj).match(/^\[object (.*)\]$/)[1];
        },
    };
-   Setup((function(){
-        return Object.create(proto);
-   })());
-})((typeof exports!=='undefined'?function(fn){module.exports=fn;}:function(fn){this['SeededShuffle']=fn;}));
+   return Object.create(proto);
+}));


### PR DESCRIPTION
Thanks a lot for making this library! We're trying it out for the TIDAL web player's "shuffle play queue" mode; writing unit tests that involve randomness is challenging, but by providing an explicit seed in unit tests, we can reliably test logic related to play queue shuffling. We've been using underscore's [shuffle](http://underscorejs.org/#shuffle) function until now, but as mentioned, it's hard to unit test.

However, we couldn't use the package as-is:

The logic used for exporting the package didn't work with Webpack bundling. Replacing it with the standard UMD header:

https://github.com/umdjs/umd

resolved the problem.